### PR TITLE
Add ItemBrowserViewModel and connect to ItemBrowserScreen.

### DIFF
--- a/app/src/main/java/com/keepingstock/ui/screens/item/ItemBrowserScreen.kt
+++ b/app/src/main/java/com/keepingstock/ui/screens/item/ItemBrowserScreen.kt
@@ -5,25 +5,71 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.keepingstock.core.contracts.UiState
+import com.keepingstock.ui.viewmodel.item.ItemBrowserViewModel
 
-@Preview(showSystemUi = false, showBackground = true)
 @Composable
 fun ItemBrowserScreen(
+    viewModel: ItemBrowserViewModel? = null,
     modifier: Modifier = Modifier,
     onOpenItem: (itemId: String) -> Unit = {},
     onOpenContainerBrowser: () -> Unit = {}
 ) {
-    Column (modifier = modifier.padding(16.dp)) {
+
+
+    Column(modifier = modifier.padding(16.dp)) {
+        // Show state info, will refactor with real UI later.
+        // Show state if viewModel exists, otherwise placeholder
+        if (viewModel != null) {
+            val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            when (val state = uiState) {
+                is UiState.Loading -> Text("Item Browser Screen (loading...)")
+                is UiState.Success -> Text("Item Browser Screen (${state.data.items.size} items)")
+                is UiState.Error -> Text("Item Browser Screen (error: ${state.message})")
+            }
+        } else {
+            Text("Item Browser Screen (placeholder)")
+        }
+        // Button to test item navigation
+        Button(
+            onClick = { onOpenItem("01") },
+            modifier = Modifier.padding(top = 12.dp)
+        ) {
+            Text("Open Example Item 01")
+        }
+        // Navigate to container browser screen
+        Button(
+            onClick = onOpenContainerBrowser,
+            modifier = Modifier.padding(top = 12.dp)
+        ) {
+            Text("Go to Container Browser (last open)")
+        }
+    }
+}
+
+@Preview(showSystemUi = false, showBackground = true)
+@Composable
+private fun ItemBrowserScreenPreview() {
+    // Preview without ViewModel
+    Column(modifier = Modifier.padding(16.dp)) {
         Text("Item Browser Screen (placeholder)")
 
-        Button(onClick = { onOpenItem("01") }, modifier = Modifier.padding(top = 12.dp)) {
+        Button(
+            onClick = {},
+            modifier = Modifier.padding(top = 12.dp)
+        ) {
             Text("Open Example Item 01")
         }
 
-        Button(onClick = onOpenContainerBrowser, modifier = Modifier.padding(top = 12.dp)) {
+        Button(
+            onClick = {},
+            modifier = Modifier.padding(top = 12.dp)
+        ) {
             Text("Go to Container Browser (last open)")
         }
     }

--- a/app/src/main/java/com/keepingstock/viewmodel/item/ItemBrowserViewModel.kt
+++ b/app/src/main/java/com/keepingstock/viewmodel/item/ItemBrowserViewModel.kt
@@ -1,0 +1,81 @@
+package com.keepingstock.ui.viewmodel.item
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.keepingstock.core.contracts.Item
+import com.keepingstock.core.contracts.ItemRepository
+import com.keepingstock.core.contracts.UiState
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+// Data needed to render the item browser UI
+data class ItemBrowserUiData(
+    val items: List<Item> = emptyList(),
+    val containerId: String? = null
+)
+
+@OptIn(FlowPreview::class)
+class ItemBrowserViewModel(
+    private val repository: ItemRepository
+) : ViewModel() {
+
+    // Current Search Text
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    // Optional filter to only show items in current container
+    private val _activeContainerId = MutableStateFlow<String?>(null)
+
+    // Exposed UI state (Loading, Success, or Error)
+    private val _uiState = MutableStateFlow<UiState<ItemBrowserUiData>>(UiState.Loading)
+    val uiState: StateFlow<UiState<ItemBrowserUiData>> = _uiState.asStateFlow()
+
+    init {
+        observeSearch()
+    }
+
+    // Combines search query and container filter, then loads when changed
+    private fun observeSearch() {
+        viewModelScope.launch {
+            combine(
+                _searchQuery.debounce(300),
+                _activeContainerId
+            ) { query, containerId ->
+                query to containerId
+            }.collect { (query, containerId) ->
+                loadItems(query, containerId)
+            }
+        }
+    }
+
+    // Update when user types in search field
+    fun updateSearchQuery(query: String) {
+        _searchQuery.value = query
+    }
+
+    // Filter by container
+    fun setContainer(containerId: String?) {
+        _activeContainerId.value = containerId
+    }
+
+    // Get items from repository based on current filters
+    private suspend fun loadItems(query: String, containerId: String?) {
+        _uiState.value = UiState.Loading
+        try {
+            val items = when {
+                query.isNotBlank() -> repository.searchItems(query, emptyList())
+                containerId != null -> repository.getItemsInContainer(containerId)
+                else -> emptyList()
+            }
+            _uiState.value = UiState.Success(
+                ItemBrowserUiData(items = items, containerId = containerId)
+            )
+        } catch (e: Exception) {
+            _uiState.value = UiState.Error(
+                message = "Failed to load items",
+                cause = e
+            )
+        }
+    }
+}


### PR DESCRIPTION
Added ItemBrowserViewModel and hooked it up to the ItemBrowserScreen. Did a temporary injection so it'll run the same as before until a refactor later.

- New "ItemBrowserViewModel" with basic "UiState" handling
- New "ItemBrowserUiData" data class
-  "itemBrowserScreen" accepts optional "viewModel" parameter
- Shows placeholder when no ViewModel provided