### PR TITLE
Add debug demo data controls and make debug gallery scrollable

### DIFF
--- a/app/src/main/java/com/keepingstock/MainActivity.kt
+++ b/app/src/main/java/com/keepingstock/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.keepingstock.data.database.KeepingStockDatabase
+import com.keepingstock.data.integration.DemoDataManager
 import com.keepingstock.data.repositories.ContainerRepositoryImpl
 import com.keepingstock.data.repositories.ItemRepositoryImpl
 import com.keepingstock.data.repositories.TagRepositoryImpl
@@ -31,13 +32,20 @@ class MainActivity : ComponentActivity() {
             itemTagDao = db.itemTagDao(),
             itemWithTagsDao = db.itemWithTagsDao()
         )
+        val demoDataManager = DemoDataManager(
+            db = db,
+            containerRepo = containerRepo,
+            itemRepo = itemRepo,
+            tagRepo = tagRepo
+        )
 
         setContent {
             KeepingStockTheme {
                 KeepingStockApp(
                     containerRepo = containerRepo,
                     itemRepo = itemRepo,
-                    tagRepo = tagRepo
+                    tagRepo = tagRepo,
+                    demoDataManager = demoDataManager
                 )
             }
         }

--- a/app/src/main/java/com/keepingstock/data/integration/DemoDataManager.kt
+++ b/app/src/main/java/com/keepingstock/data/integration/DemoDataManager.kt
@@ -1,0 +1,90 @@
+package com.keepingstock.data.integration
+
+import androidx.room.withTransaction
+import com.keepingstock.data.database.KeepingStockDatabase
+import com.keepingstock.data.repositories.ContainerRepositoryImpl
+import com.keepingstock.data.repositories.ItemRepositoryImpl
+import com.keepingstock.data.repositories.TagRepositoryImpl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Provides repeatable demo data actions for debug builds.
+ */
+class DemoDataManager(
+    private val db: KeepingStockDatabase,
+    private val containerRepo: ContainerRepositoryImpl,
+    private val itemRepo: ItemRepositoryImpl,
+    private val tagRepo: TagRepositoryImpl,
+) {
+    /**
+     * Inserts a new batch of demo data.
+     */
+    suspend fun loadDemoData() = db.withTransaction { insertDemoData() }
+
+    /**
+     * Removes all user data.
+     */
+    suspend fun clearAllData() {
+        withContext(Dispatchers.IO) {
+            db.clearAllTables()
+        }
+    }
+
+    /**
+     * Replaces existing data with a known demo dataset.
+     */
+    suspend fun resetToDemoData() {
+        clearAllData()
+        db.withTransaction {
+            insertDemoData()
+        }
+    }
+
+    private suspend fun insertDemoData() {
+        val house = containerRepo.createContainer(
+            name = "House",
+            description = "Primary demo root",
+            imageUri = "demo"
+        )
+        val garage = containerRepo.createContainer(
+            name = "Garage",
+            description = "Tools and storage",
+            imageUri = "demo2",
+            parentContainerId = house.id
+        )
+        val hallCloset = containerRepo.createContainer(
+            name = "Hall Closet",
+            description = "Seasonal supplies and small gear",
+            parentContainerId = house.id
+        )
+
+        val toolsTag = tagRepo.createTag("tools")
+        val seasonalTag = tagRepo.createTag("seasonal")
+        val campingTag = tagRepo.createTag("camping")
+
+        val drill = itemRepo.createItem(
+            name = "Cordless Drill",
+            description = "18V driver kit",
+            imageUri = "demo",
+            containerId = garage.id
+        )
+        val lantern = itemRepo.createItem(
+            name = "Camping Lantern",
+            description = "Battery powered lantern",
+            imageUri = "demo2",
+            containerId = hallCloset.id
+        )
+        val tapeMeasure = itemRepo.createItem(
+            name = "Tape Measure",
+            description = "Loose item for unsorted view",
+            imageUri = null,
+            containerId = null
+        )
+
+        tagRepo.linkTagToItem(drill.id, toolsTag.id)
+        tagRepo.linkTagToItem(lantern.id, seasonalTag.id)
+        tagRepo.linkTagToItem(lantern.id, campingTag.id)
+        tagRepo.linkTagToItem(tapeMeasure.id, toolsTag.id)
+    }
+}

--- a/app/src/main/java/com/keepingstock/ui/KeepingStockApp.kt
+++ b/app/src/main/java/com/keepingstock/ui/KeepingStockApp.kt
@@ -26,6 +26,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.keepingstock.data.integration.DemoDataManager
 import com.keepingstock.data.repositories.ContainerRepositoryImpl
 import com.keepingstock.data.repositories.ItemRepositoryImpl
 import com.keepingstock.data.repositories.TagRepositoryImpl
@@ -45,7 +46,8 @@ import kotlinx.coroutines.launch
 fun KeepingStockApp(
     containerRepo: ContainerRepositoryImpl,
     itemRepo: ItemRepositoryImpl,
-    tagRepo: TagRepositoryImpl
+    tagRepo: TagRepositoryImpl,
+    demoDataManager: DemoDataManager
 ) {
     // Single NavController instance for the entire app. Owned here so global UI can trigger
     // navigation (i.e. top bar and bottom bar)
@@ -114,6 +116,7 @@ fun KeepingStockApp(
             containerRepo = containerRepo,
             itemRepo = itemRepo,
             tagRepo = tagRepo,
+            demoDataManager = demoDataManager,
             navController = navController,
             contentPadding = innerPadding,
             onTopBarChange = { topBarConfig = it },

--- a/app/src/main/java/com/keepingstock/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/keepingstock/ui/navigation/AppNavGraph.kt
@@ -12,6 +12,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.keepingstock.core.contracts.ContainerId
 import com.keepingstock.core.contracts.Routes
+import com.keepingstock.data.integration.DemoDataManager
 import com.keepingstock.data.repositories.ContainerRepositoryImpl
 import com.keepingstock.data.repositories.ItemRepositoryImpl
 import com.keepingstock.data.repositories.TagRepositoryImpl
@@ -57,6 +58,7 @@ fun AppNavGraph(
     containerRepo: ContainerRepositoryImpl,
     itemRepo: ItemRepositoryImpl,
     tagRepo: TagRepositoryImpl,
+    demoDataManager: DemoDataManager,
     navController: NavHostController,
     contentPadding: PaddingValues,
     onTopBarChange: (TopBarConfig) -> Unit,
@@ -72,7 +74,8 @@ fun AppNavGraph(
         showSnackbar = showSnackbar,
         containerRepo = containerRepo,
         itemRepo = itemRepo,
-        tagRepo = tagRepo
+        tagRepo = tagRepo,
+        demoDataManager = demoDataManager
     )
 
     // The place in UI where the active destination composable is displayed

--- a/app/src/main/java/com/keepingstock/ui/navigation/NavDeps.kt
+++ b/app/src/main/java/com/keepingstock/ui/navigation/NavDeps.kt
@@ -1,6 +1,7 @@
 package com.keepingstock.ui.navigation
 
 import androidx.navigation.NavHostController
+import com.keepingstock.data.integration.DemoDataManager
 import com.keepingstock.data.repositories.ContainerRepositoryImpl
 import com.keepingstock.data.repositories.ItemRepositoryImpl
 import com.keepingstock.data.repositories.TagRepositoryImpl
@@ -15,5 +16,6 @@ internal data class NavDeps(
     val showSnackbar: (String) -> Unit,
     val containerRepo: ContainerRepositoryImpl,
     val itemRepo: ItemRepositoryImpl,
-    val tagRepo: TagRepositoryImpl
+    val tagRepo: TagRepositoryImpl,
+    val demoDataManager: DemoDataManager
 )

--- a/app/src/main/java/com/keepingstock/ui/navigation/destinations/debug/DebugGalleryDestination.kt
+++ b/app/src/main/java/com/keepingstock/ui/navigation/destinations/debug/DebugGalleryDestination.kt
@@ -2,17 +2,21 @@ package com.keepingstock.ui.navigation.destinations.debug
 
 import android.net.Uri
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.keepingstock.ui.navigation.NavDeps
 import com.keepingstock.ui.navigation.NavRoute
 import com.keepingstock.ui.scaffold.TopBarConfig
 import com.keepingstock.ui.screens.debug.DebugGalleryScreen
+import kotlinx.coroutines.launch
 
 internal fun NavGraphBuilder.addDebugGalleryDestination(
     deps: NavDeps
 ) {
     composable(route = NavRoute.DebugGallery.route) {
+        val scope = rememberCoroutineScope()
+
         LaunchedEffect(Unit) {
             deps.onTopBarChange(
                 TopBarConfig(
@@ -23,6 +27,27 @@ internal fun NavGraphBuilder.addDebugGalleryDestination(
         }
 
         DebugGalleryScreen(
+            onLoadDemoData = {
+                scope.launch {
+                    runCatching { deps.demoDataManager.loadDemoData() }
+                        .onSuccess { deps.showSnackbar("Demo data added.") }
+                        .onFailure { deps.showSnackbar("Load failed: ${it.message}") }
+                }
+            },
+            onResetToDemoData = {
+                scope.launch {
+                    runCatching { deps.demoDataManager.resetToDemoData() }
+                        .onSuccess { deps.showSnackbar("Demo data reset.") }
+                        .onFailure { deps.showSnackbar("Reset failed: ${it.message}") }
+                }
+            },
+            onClearAllData = {
+                scope.launch {
+                    runCatching { deps.demoDataManager.clearAllData() }
+                        .onSuccess { deps.showSnackbar("All data cleared.") }
+                        .onFailure { deps.showSnackbar("Clear failed: ${it.message}") }
+                }
+            },
             onOpenContainerBrowser = {
                 deps.navController.navigate(NavRoute.ContainerBrowser.createRoute(null))
             },

--- a/app/src/main/java/com/keepingstock/ui/screens/debug/DebugGalleryScreen.kt
+++ b/app/src/main/java/com/keepingstock/ui/screens/debug/DebugGalleryScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -18,6 +20,9 @@ import com.keepingstock.ui.theme.KeepingStockTheme
 // Add callback functions for custom screens here
 @Composable
 fun DebugGalleryScreen(
+    onLoadDemoData: () -> Unit,
+    onResetToDemoData: () -> Unit,
+    onClearAllData: () -> Unit,
     onOpenContainerBrowser: () -> Unit,
     onOpenItemBrowser: () -> Unit,
     onOpenQrScan: () -> Unit,
@@ -29,6 +34,7 @@ fun DebugGalleryScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -47,9 +53,13 @@ fun DebugGalleryScreen(
         )
         Text(
             text = "Use these shortcuts to test screens in the emulator. " +
-                    "Do not add navigation graphs or change MainActivity.",
+                    "You can also add, reset, or clear demo data here.",
             style = MaterialTheme.typography.bodyMedium
         )
+
+        DebugButton("Load Demo Data", onLoadDemoData)
+        DebugButton("Reset To Demo Data", onResetToDemoData)
+        DebugButton("Clear All Data", onClearAllData)
 
         DebugButton("Container Browser", onOpenContainerBrowser)
         DebugButton("Item Browser", onOpenItemBrowser)
@@ -83,6 +93,9 @@ private fun DebugButton(
 private fun DebugGalleryScreenPreview() {
     KeepingStockTheme {
         DebugGalleryScreen(
+            onLoadDemoData = {},
+            onResetToDemoData = {},
+            onClearAllData = {},
             onOpenContainerBrowser = {},
             onOpenItemBrowser = {},
             onOpenQrScan = {},


### PR DESCRIPTION
**Summary**

This PR adds a simple debug-only demo data workflow so the app can be reset for demos without manually re-entering data.

Adds DemoDataManager to seed a fixed set of demo containers, items, and tags
Adds debug gallery actions for:
Load Demo Data
Reset To Demo Data
Clear All Data
Wires the demo data manager from MainActivity through the app navigation dependencies
Adds snackbar feedback for each debug action
Makes the debug gallery vertically scrollable so all buttons are accessible on smaller screens

Load Demo Data appends another demo dataset each time it is tapped. For a clean, repeatable demo state, use Reset To Demo Data.

**Testing**

Ran .\gradlew.bat :app:compileDebugKotlin
Verified the debug gallery can scroll
Verified demo data actions are available from the debug gallery